### PR TITLE
情報科学類の履修要件を一部修正

### DIFF
--- a/public/data/requirements/2024-coins-iim.json
+++ b/public/data/requirements/2024-coins-iim.json
@@ -22,7 +22,7 @@
               "id": "grup_BSbGtNqN_Pqo2ubD7nGgJ",
               "includeRules": {
                 "courseNames": [
-                  "知能情報メディア実験",
+                  "知能情報メディア実験A",
                   "知能情報メディア実験B",
                   "卒業研究A",
                   "卒業研究B",
@@ -52,6 +52,9 @@
               "includeRules": {
                 "prefixes": ["GB2", "GB3", "GB4", "GA4"],
                 "courseNames": ["情報科学特別演習", "情報特別演習I", "情報特別演習II"]
+              },
+              "excludeRules": {
+                "prefixes": ["GB20", "GB30", "GB40"]
               }
             }
           ]

--- a/public/data/requirements/2024-coins-isys.json
+++ b/public/data/requirements/2024-coins-isys.json
@@ -22,7 +22,7 @@
               "id": "grup_KuHvk-5doPMfCwcNhw8eL",
               "includeRules": {
                 "courseNames": [
-                  "情報システム実験",
+                  "情報システム実験A",
                   "情報システム実験B",
                   "卒業研究A",
                   "卒業研究B",
@@ -52,6 +52,9 @@
               "includeRules": {
                 "prefixes": ["GB2", "GB3", "GB4", "GA4"],
                 "courseNames": ["情報科学特別演習", "情報特別演習I", "情報特別演習II"]
+              },
+              "excludeRules": {
+                "prefixes": ["GB20", "GB30", "GB40"]
               }
             }
           ]

--- a/public/data/requirements/2024-coins-software.json
+++ b/public/data/requirements/2024-coins-software.json
@@ -22,7 +22,7 @@
               "id": "grup_QcRz1CkM6jxJOaHJLM63A",
               "includeRules": {
                 "courseNames": [
-                  "ソフトウェアサイエンス実験",
+                  "ソフトウェアサイエンス実験A",
                   "ソフトウェアサイエンス実験B",
                   "卒業研究A",
                   "卒業研究B",
@@ -52,6 +52,9 @@
               "includeRules": {
                 "prefixes": ["GB2", "GB3", "GB4", "GA4"],
                 "courseNames": ["情報科学特別演習", "情報特別演習I", "情報特別演習II"]
+              },
+              "excludeRules": {
+                "prefixes": ["GB20", "GB30", "GB40"]
               }
             }
           ]


### PR DESCRIPTION
情報科学類の履修要件が正しく設定されていない問題を修正しました。

- 専門科目—必修科目の主専攻実験Aの科目名が誤っていたのを修正
- 専門科目—選択科目の GB{20,30,40} から始まる科目が、GB{2,3,4} から始まる科目の枠に吸われて0単位になってしまっていたのを修正

### 複数の場所に該当する科目について
今回の事例では、GB2, 3, 4 側が 0 単位以上でよいので、20, 30, 40 を exclude して対応しましたが、優先順位付けをする、不足分を優先的に埋めるなどの機能があるほうが良いかもしれません。

### 既知の問題
未履修の科目について、実際の単位数にかかわらず 2 単位と表示されてしまっており、結果として全体の必要単位数など大部分の集計が正しく表示されない。

例：卒業研究A/B は 3 単位だが、2 単位と表示されてしまっており、結果として専門科目全体の単位数（正しくは50単位）も誤って表示される。
<img width="743" height="356" alt="情報科学類の専門科目部分のスクリーンショット" src="https://github.com/user-attachments/assets/d18c8a54-d1bf-4ec5-b203-08cfba8db838" />

https://github.com/nito-008/tokutan/blob/7d57cadf54c77dfab9d61891c7a9cc572dcbdc3d/src/lib/calculator/requirements.ts#L268